### PR TITLE
Add GitHub Skills activity to activities list

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -75,6 +75,13 @@ activities = {
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
     }
+    ,
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills with GitHub. First part of the GitHub Certifications program, supporting college applications.",
+        "schedule": "Wednesdays, 4:30 PM - 5:30 PM",
+        "max_participants": 25,
+        "participants": []
+    }
 }
 
 


### PR DESCRIPTION
This pull request adds the "GitHub Skills" activity to the in-memory activities database, making it available for student registration as announced by the principal. The activity supports the new partnership with GitHub and is time-sensitive for student signups.